### PR TITLE
There is no file called readlogs.html switching it to the actual file

### DIFF
--- a/logtailer/views.py
+++ b/logtailer/views.py
@@ -14,7 +14,7 @@ HISTORY_LINES = getattr(settings, 'LOGTAILER_HISTORY_LINES', 0)
 
 def read_logs(request):
     context = {}
-    return render_to_response('logtailer/readlogs.html',
+    return render_to_response('logtailer/log_reader.html',
                               context, 
                               RequestContext(request, {}),)
 


### PR DESCRIPTION
There was an issue with the template name. Made a small bug/quick fix
