### PR TITLE
made compatible with python 3.6

### DIFF
--- a/logtailer/views.py
+++ b/logtailer/views.py
@@ -31,7 +31,7 @@ def get_history(f, lines=HISTORY_LINES):
     while size > 0 and bytes > 0:
         if bytes - buffer_size > 0:
             # Seek back one whole buffer_size
-            f.seek(block*buffer_size, 2)
+            f.seek(f.tell()+block*buffer_size, 0)
             # read buffer
             data.append(f.read(buffer_size))
         else:
@@ -41,10 +41,9 @@ def get_history(f, lines=HISTORY_LINES):
             data.append(f.read(bytes))
         linesFound = data[-1].count('\n')
         size -= linesFound
-        bytes -= buffer_size
+        bytes += block*buffer_size
         block -= 1
     return ''.join(data).splitlines(True)[-lines:]
-
 
 @staff_member_required
 def get_log_lines(request, file_id, history=False):


### PR DESCRIPTION
-- " f.seek(block*buffer_size, 2)"  was giving error "io.UnsupportedOperation: can't do nonzero end-relative seeks" in python 3.6
-- Error was most probably because of
from documentation of python 3.6  ([readthedocs](http://python-reference.readthedocs.io/en/latest/docs/file/seek.html))  ([official documention](http://docs.python.org/3.6/tutorial/inputoutput.html#methods-of-file-objects))

> In text files (those opened without a "b" in the mode string), only seeks relative to the beginning of the file are allowed (the exception being seeking to the very file end with seek(0, 2)).
> In text files (those opened without a "b" in the mode string), only seeks relative to the beginning of the file [os.SEEK_SET] are allowed...

However, Adding the "b" flag when you are reading or writing text can have unintended consequences, therefore I avoided that.
I made the appropriate changes in views.py file to make it work in pythn3.6 